### PR TITLE
Update the default options to handle a null resize

### DIFF
--- a/class-imagify.php
+++ b/class-imagify.php
@@ -4,17 +4,17 @@
  * Imagify PHP Class
  *
  * @author WP Media <contact@wp-media.me>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,7 +26,8 @@
 
 namespace Imagify;
 
-class Optimizer {
+class Optimizer
+{
     /**
      * The Imagify API endpoint
      */
@@ -36,24 +37,24 @@ class Optimizer {
      * The Imagify API key
      */
     private $api_key = '';
-
     /**
      * HTTP headers
      */
-    private $headers = array();
+    private $headers = [];
 
     /**
      * The constructor
      *
      * @return void
      */
-    public function __construct( $api_key = '' ) {
-        if ( ! empty( $api_key ) ) {
+    public function __construct($api_key = '')
+    {
+        if (!empty($api_key)) {
             $this->api_key = $api_key;
         }
 
         // Check if php-curl is enabled
-        if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_exec' ) ) {
+        if (!function_exists('curl_init') || !function_exists('curl_exec')) {
             die('cURL isn\'t installed on the server.');
         }
 
@@ -63,8 +64,8 @@ class Optimizer {
     /**
      * Optimize an image from its binary content.
      *
-     * @param  string $image   Image path
-     * @param  array  $options (optional) Optimization options
+     * @param string $image Image path
+     * @param array $options (optional) Optimization options
      *                         array(
      *                             'level'     => string ('normal' | 'aggressive' (default) | 'ultra'),
      *                             'resize'    => array(
@@ -73,89 +74,98 @@ class Optimizer {
      *                                 'percent' => int
      *                             ),
      *                             'keep_exif' => bool (default: false)
-     *                         ) 
+     *                         )
+     *
      * @return array
      */
-    public function optimize( $image, $options = array() ) {
-        if ( !is_string($image) || !is_file($image) ) {
-            return (object) array('success' => false, 'message' => 'Image incorrect!');
-        } else if ( !is_readable($image) ) {
-            return (object) array('success' => false, 'message' => 'Image not readable!');
+    public function optimize($image, $options = [])
+    {
+        if (!is_string($image) || !is_file($image)) {
+            return (object)['success' => false, 'message' => 'Image incorrect!'];
+        } elseif (!is_readable($image)) {
+            return (object)['success' => false, 'message' => 'Image not readable!'];
         }
 
-        $default = array(
+        $default = [
             'level'     => 'aggressive',
-            'resize'    => array(),
+            'resize'    => [],
             'keep_exif' => false,
-            'timeout'   => 45 
-        );
+            'timeout'   => 45,
+        ];
 
-        $options = array_merge( $default, $options );
-        
-        $data = array(
-            'image' => curl_file_create( $image ),
-            'data'  => json_encode(
-                array(
-                    'aggressive' => ( 'aggressive' === $options['level'] ) ? true : false,
-                    'ultra'      => ( 'ultra' === $options['level'] ) ? true : false,
-                    'resize'     => $options['resize'],
-                    'keep_exif'  => $options['keep_exif'],
-                ) 
-            )
-        );
+        $options = array_merge($default, $options);
 
-        return $this->request( '/upload/', array( 
-                'post_data' => $data,
-                'timeout'   => $options["timeout"]
-            ) 
-        );
+        $jsonData = [
+            'aggressive' => ('aggressive' === $options['level']) ? true : false,
+            'ultra'      => ('ultra' === $options['level']) ? true : false,
+            'resize'     => $options['resize'],
+            'keep_exif'  => $options['keep_exif'],
+        ];
+
+        //if the resize option is blank, leave it out
+        if ([] === $options['resize']) {
+            unset($jsonData['resize']);
+        }
+
+        $data = [
+            'image' => curl_file_create($image),
+            'data'  => json_encode($jsonData),
+        ];
+
+        return $this->request('/upload/', [
+            'post_data' => $data,
+            'timeout'   => $options["timeout"],
+        ]);
     }
 
     /**
      * Make an HTTP call using curl.
      *
-     * @param  string $url       The URL to call
-     * @param  array  $options   Optional request options
+     * @param string $url The URL to call
+     * @param array $options Optional request options
+     *
      * @return object
      */
-    private function request( $url, $options = array() ) {
-        $default = array( 
-            'method'    => 'POST', 
-            'post_data' => null
-        );
-        $options = array_merge( $default, $options );
+    private function request($url, $options = [])
+    {
+        $default = [
+            'method'    => 'POST',
+            'post_data' => null,
+        ];
+        $options = array_merge($default, $options);
 
         try {
             $ch     = curl_init();
-            $is_ssl = ( isset( $_SERVER['HTTPS'] ) && ( 'on' == strtolower( $_SERVER['HTTPS'] ) || '1' == $_SERVER['HTTPS'] ) ) || ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) );
+            $is_ssl = (isset($_SERVER['HTTPS']) && ('on' == strtolower(
+                            $_SERVER['HTTPS']
+                        ) || '1' == $_SERVER['HTTPS'])) || (isset($_SERVER['SERVER_PORT']) && ('443' == $_SERVER['SERVER_PORT']));
 
-            if ( 'POST' === $options['method'] ) {
-                curl_setopt( $ch, CURLOPT_POST, true );
-                curl_setopt( $ch, CURLOPT_POSTFIELDS, $options['post_data'] );
+            if ('POST' === $options['method']) {
+                curl_setopt($ch, CURLOPT_POST, true);
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $options['post_data']);
             }
 
-            curl_setopt( $ch, CURLOPT_URL, self::API_ENDPOINT . $url );
-            curl_setopt( $ch, CURLOPT_USERAGENT, 'Imagify PHP Class');
-            curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-            curl_setopt( $ch, CURLOPT_HTTPHEADER, $this->headers );
-            curl_setopt( $ch, CURLOPT_TIMEOUT, $options['timeout'] );
-            @curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
-            curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, $is_ssl );
-            
-            $response  = json_decode( curl_exec( $ch ) );
-            $error     = curl_error( $ch );
-            $http_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+            curl_setopt($ch, CURLOPT_URL, self::API_ENDPOINT . $url);
+            curl_setopt($ch, CURLOPT_USERAGENT, 'Imagify PHP Class');
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $this->headers);
+            curl_setopt($ch, CURLOPT_TIMEOUT, $options['timeout']);
+            @curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $is_ssl);
 
-            curl_close( $ch );
+            $response  = json_decode(curl_exec($ch));
+            $error     = curl_error($ch);
+            $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        } catch( \Exception $e ) {
-            return (object) array('success' => false, 'message' => 'Unknown error occurred');
+            curl_close($ch);
+        } catch (\Exception $e) {
+            return (object)['success' => false, 'message' => 'Unknown error occurred', 'response' => $e];
         }
 
-        if ( 200 !== $http_code && isset( $response->code, $response->detail ) ) {
+        if (200 !== $http_code && isset($response->code, $response->detail)) {
             return $response;
-        } elseif ( 200 !== $http_code ) {
-            return (object) array('success' => false, 'message' => 'Unknown error occurred');
+        } elseif (200 !== $http_code) {
+            return (object)['success' => false, 'message' => 'Invalid response code', 'response' => $response];
         }
 
         return $response;


### PR DESCRIPTION
By leaving the resize option in the data object as an empty array, the API responds with an error message. To fix this, the code is now detecting if the resize option was passed in... if it was not, it simply removes resize from the json ecoded string.

Next, I updated your error messages to include 'response'. This will allow much easier debugging instead of simply returning "Unknown error"

I updated the spacing and code style to match the code style standards that all popular php frameworks, like Laravel and Symphony, use.

Finally, I modified the use of array() to leverage the [] brackets instead. Bracket array support was added with php version 5.4, which was released in 2013.

If any of these updates are unwelcomed, let me know and I'll happily make the updates. Fixing this issue in this repo and updating composer will simplify support for myself and everyone else using this..